### PR TITLE
Port GPU HUD warp from TFORevive

### DIFF
--- a/bmedll/Hudwarp.cpp
+++ b/bmedll/Hudwarp.cpp
@@ -1,0 +1,378 @@
+#include "Hudwarp.h"
+#include <d3dcompiler.h>
+
+// Ported from TFORevive by Barnaby
+
+bool CompileShader(const char* szShader, const char* szEntrypoint, const char* szTarget, ID3D10Blob** pBlob)
+{
+	ID3D10Blob* pErrorBlob = nullptr;
+
+	auto hr = D3DCompile(szShader, strlen(szShader), 0, nullptr, nullptr, szEntrypoint, szTarget, D3DCOMPILE_ENABLE_STRICTNESS, 0, pBlob, &pErrorBlob);
+	if (FAILED(hr))
+	{
+		if (pErrorBlob)
+		{
+			char szError[256]{ 0 };
+			memcpy(szError, pErrorBlob->GetBufferPointer(), pErrorBlob->GetBufferSize());
+			MessageBoxA(nullptr, szError, "Error", MB_OK);
+		}
+		return false;
+	}
+	return true;
+}
+
+ID3D11VertexShader* pVertexShader;
+ID3D11PixelShader* pPixelShader;
+
+#define MAINVP 0
+D3D11_VIEWPORT pViewports[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE]{ 0 };
+
+HudwarpProcess::HudwarpProcess(ID3D11Device* pDevice, ID3D11DeviceContext** ppID3D11DeviceContext) : m_pDevice(pDevice), m_pContext(*ppID3D11DeviceContext)
+{
+	// Initialize shaders
+	ID3D10Blob* pBlob = nullptr;
+
+	// Create vertex shader
+	if (!pVertexShader)
+	{
+		if (!CompileShader(hudwarpShader, "VS", "vs_5_0", &pBlob))
+			return;
+
+		HRESULT hr = pDevice->CreateVertexShader(pBlob->GetBufferPointer(), pBlob->GetBufferSize(), nullptr, &pVertexShader);
+		if (FAILED(hr))
+			return;
+	}
+
+	// Define/create the input layout for the vertex shader
+	D3D11_INPUT_ELEMENT_DESC layout[2] = {
+		{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+		{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+	};
+	UINT numElements = ARRAYSIZE(layout);
+
+	HRESULT hr = pDevice->CreateInputLayout(layout, numElements, pBlob->GetBufferPointer(), pBlob->GetBufferSize(), &m_pVertexLayout);
+	if (FAILED(hr))
+		return;
+
+	// Create pixel shader
+	if (!pPixelShader)
+	{
+		if (!CompileShader(hudwarpShader, "PS", "ps_5_0", &pBlob))
+			return;
+
+		hr = pDevice->CreatePixelShader(pBlob->GetBufferPointer(), pBlob->GetBufferSize(), nullptr, &pPixelShader);
+		if (FAILED(hr))
+			return;
+	}
+
+	static DWORD64 vguimatsurfacedllBaseAddress = Util::GetModuleBaseAddress("materialsystem_dx11.dll");
+	m_width = *reinterpret_cast<unsigned int*>(vguimatsurfacedllBaseAddress + 0x290DD8);
+	m_height = *reinterpret_cast<unsigned int*>(vguimatsurfacedllBaseAddress + 0x290DD8 + 4);
+
+	// Setup the texture descriptor
+	D3D11_TEXTURE2D_DESC textureDesc;
+	ZeroMemory(&textureDesc, sizeof(textureDesc));
+	textureDesc.Width = m_width;
+	textureDesc.Height = m_height;
+	textureDesc.MipLevels = 1;
+	textureDesc.ArraySize = 1;
+	textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+	textureDesc.SampleDesc.Count = 1;
+	textureDesc.Usage = D3D11_USAGE_DEFAULT;
+	textureDesc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+	textureDesc.CPUAccessFlags = 0;
+	textureDesc.MiscFlags = 0;
+
+	// Create the render texture
+	m_pDevice->CreateTexture2D(&textureDesc, NULL, &m_pRenderTexture);
+
+	// Setup the render target view descriptor
+	D3D11_RENDER_TARGET_VIEW_DESC renderTargetViewDesc;
+	renderTargetViewDesc.Format = textureDesc.Format;
+	renderTargetViewDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+	renderTargetViewDesc.Texture2D.MipSlice = 0;
+
+	// Create the render target view.
+	m_pDevice->CreateRenderTargetView(m_pRenderTexture, &renderTargetViewDesc, &m_pRenderTargetView);
+
+	// Setup the shader resource view descriptor
+	D3D11_SHADER_RESOURCE_VIEW_DESC shaderResourceViewDesc;
+	shaderResourceViewDesc.Format = textureDesc.Format;
+	shaderResourceViewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+	shaderResourceViewDesc.Texture2D.MostDetailedMip = 0;
+	shaderResourceViewDesc.Texture2D.MipLevels = 1;
+
+	// Create the shader resource view.
+	m_pDevice->CreateShaderResourceView(m_pRenderTexture, &shaderResourceViewDesc, &m_pShaderResourceView);
+
+	// Create the constant buffer
+	D3D11_BUFFER_DESC bd{ 0 };
+	bd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+	bd.ByteWidth = sizeof(ConstantBuffer);
+	bd.Usage = D3D11_USAGE_DEFAULT;
+
+	// Setup orthographic projection
+	mOrtho = XMMatrixOrthographicLH(1.0f, 1.0f, 0.0f, 1.0f);
+	ConstantBuffer cb;
+	cb.mProjection = mOrtho;
+	cb.xWarp = 0.0f;
+	cb.xScale = 1.0f;
+	cb.yWarp = 0.0f;
+	cb.yScale = 1.0f;
+	cb.viewDist = 1.0f;
+
+	D3D11_SUBRESOURCE_DATA sr{ 0 };
+	sr.pSysMem = &cb;
+	pDevice->CreateBuffer(&bd, &sr, &m_pConstantBuffer);
+
+	// Create a triangle to render
+	// Create a vertex buffer, start by setting up a description.
+	ZeroMemory(&bd, sizeof(bd));
+	bd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+	bd.Usage = D3D11_USAGE_DEFAULT;
+	bd.ByteWidth = 4 * sizeof(Vertex);
+	bd.StructureByteStride = sizeof(Vertex);
+
+	// left and top edge of window
+	float left = 1.0f / -2;
+	float right = 1.0f / 2;
+	float top = 1.0f / 2;
+	float bottom = 1.0f / -2;
+
+	Vertex pVerts[4] = {
+		{ XMFLOAT3(left, top, 1.0f), XMFLOAT2(0.0f, 0.0f) },
+		{ XMFLOAT3(right, top, 1.0f), XMFLOAT2(1.0f, 0.0f) },
+		{ XMFLOAT3(right, bottom, 1.0f), XMFLOAT2(1.0f, 1.0f) },
+		{ XMFLOAT3(left, bottom, 1.0f), XMFLOAT2(0.0f, 1.0f) },
+	};
+
+	// create the buffer.
+	ZeroMemory(&sr, sizeof(sr));
+	sr.pSysMem = &pVerts;
+	pDevice->CreateBuffer(&bd, &sr, &m_pVertexBuffer);
+
+	// Create an index buffer
+	ZeroMemory(&bd, sizeof(bd));
+	ZeroMemory(&sr, sizeof(sr));
+
+	UINT pIndices[6] = { 0, 1, 2, 0, 2, 3 };
+	bd.BindFlags = D3D11_BIND_INDEX_BUFFER;
+	bd.Usage = D3D11_USAGE_DEFAULT;
+	bd.ByteWidth = sizeof(UINT) * 6;
+	bd.StructureByteStride = sizeof(UINT);
+
+	sr.pSysMem = &pIndices;
+	pDevice->CreateBuffer(&bd, &sr, &m_pIndexBuffer);
+
+	// Describe the Sample State
+	D3D11_SAMPLER_DESC sampDesc;
+	ZeroMemory(&sampDesc, sizeof(sampDesc));
+	sampDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+	sampDesc.AddressU = D3D11_TEXTURE_ADDRESS_WRAP;
+	sampDesc.AddressV = D3D11_TEXTURE_ADDRESS_WRAP;
+	sampDesc.AddressW = D3D11_TEXTURE_ADDRESS_WRAP;
+	sampDesc.ComparisonFunc = D3D11_COMPARISON_NEVER;
+	sampDesc.MinLOD = 0;
+	sampDesc.MaxLOD = D3D11_FLOAT32_MAX;
+
+	//Create the Sample State
+	pDevice->CreateSamplerState(&sampDesc, &m_pSamplerState);
+
+	// Create Enabled Blend State
+	D3D11_RENDER_TARGET_BLEND_DESC rt_blend_desc;
+	ZeroMemory(&rt_blend_desc, sizeof(rt_blend_desc));
+	rt_blend_desc.BlendEnable = true;
+	rt_blend_desc.SrcBlend = D3D11_BLEND_ONE;
+	rt_blend_desc.DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
+	rt_blend_desc.BlendOp = D3D11_BLEND_OP_ADD;
+	rt_blend_desc.SrcBlendAlpha = D3D11_BLEND_INV_DEST_ALPHA;
+	rt_blend_desc.DestBlendAlpha = D3D11_BLEND_ONE;
+	rt_blend_desc.BlendOpAlpha = D3D11_BLEND_OP_ADD;
+	rt_blend_desc.RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+
+	D3D11_BLEND_DESC blend_desc;
+	ZeroMemory(&blend_desc, sizeof(blend_desc));
+	blend_desc.AlphaToCoverageEnable = false;
+	blend_desc.IndependentBlendEnable = false;
+	blend_desc.RenderTarget[0] = rt_blend_desc;
+
+	pDevice->CreateBlendState(&blend_desc, &m_pBlendState);
+
+	D3D11_RASTERIZER_DESC cmdesc;
+
+	ZeroMemory(&cmdesc, sizeof(D3D11_RASTERIZER_DESC));
+	cmdesc.FillMode = D3D11_FILL_SOLID;
+	cmdesc.CullMode = D3D11_CULL_BACK;
+	cmdesc.FrontCounterClockwise = false;
+	pDevice->CreateRasterizerState(&cmdesc, &m_pCWcullMode);
+}
+
+HudwarpProcess::~HudwarpProcess()
+{
+	m_pRenderTexture->Release();
+	m_pRenderTargetView->Release();
+	m_pShaderResourceView->Release();
+	m_pSamplerState->Release();
+	m_pBlendState->Release();
+	m_pVertexBuffer->Release();
+	m_pVertexBuffer->Release();
+	m_pIndexBuffer->Release();
+	m_pConstantBuffer->Release();
+	m_pCWcullMode->Release();
+}
+
+void HudwarpProcess::Resize(unsigned int w, unsigned int h)
+{
+	// Release render target
+	m_pRenderTexture->Release();
+	m_pRenderTargetView->Release();
+
+	// Create new render target
+	static DWORD64 vguimatsurfacedllBaseAddress = Util::GetModuleBaseAddress("materialsystem_dx11.dll");
+	m_width = *reinterpret_cast<unsigned int*>(vguimatsurfacedllBaseAddress + 0x290DD8);
+	m_height = *reinterpret_cast<unsigned int*>(vguimatsurfacedllBaseAddress + 0x290DD8 + 4);
+
+	// Setup the texture descriptor
+	D3D11_TEXTURE2D_DESC textureDesc;
+	ZeroMemory(&textureDesc, sizeof(textureDesc));
+	textureDesc.Width = m_width;
+	textureDesc.Height = m_height;
+	textureDesc.MipLevels = 1;
+	textureDesc.ArraySize = 1;
+	textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+	textureDesc.SampleDesc.Count = 1;
+	textureDesc.Usage = D3D11_USAGE_DEFAULT;
+	textureDesc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+	textureDesc.CPUAccessFlags = 0;
+	textureDesc.MiscFlags = 0;
+
+	// Create the render texture
+	m_pDevice->CreateTexture2D(&textureDesc, NULL, &m_pRenderTexture);
+
+	// Setup the render target view descriptor
+	D3D11_RENDER_TARGET_VIEW_DESC renderTargetViewDesc;
+	renderTargetViewDesc.Format = textureDesc.Format;
+	renderTargetViewDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+	renderTargetViewDesc.Texture2D.MipSlice = 0;
+
+	// Create the render target view.
+	m_pDevice->CreateRenderTargetView(m_pRenderTexture, &renderTargetViewDesc, &m_pRenderTargetView);
+
+	// Setup the shader resource view descriptor
+	D3D11_SHADER_RESOURCE_VIEW_DESC shaderResourceViewDesc;
+	shaderResourceViewDesc.Format = textureDesc.Format;
+	shaderResourceViewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+	shaderResourceViewDesc.Texture2D.MostDetailedMip = 0;
+	shaderResourceViewDesc.Texture2D.MipLevels = 1;
+
+	// Create the shader resource view.
+	m_pDevice->CreateShaderResourceView(m_pRenderTexture, &shaderResourceViewDesc, &m_pShaderResourceView);
+}
+
+void HudwarpProcess::UpdateSettings(HudwarpSettings* hudwarpSettings)
+{
+	m_hudwarpSettings = *hudwarpSettings;
+}
+
+void HudwarpProcess::Begin()
+{
+	// Get the current render target
+	m_pContext->OMGetRenderTargets(1, &m_pOriginalRenderTargetView, &m_pOriginalDepthStencilView);
+
+	// Set our render target
+	m_pContext->OMSetRenderTargets(1, &m_pRenderTargetView, NULL);
+
+	// Clear the render target
+	float bgColor[4]{ 0.0f, 0.0f, 0.0f, 0.0f };
+	m_pContext->ClearRenderTargetView(m_pRenderTargetView, bgColor);
+}
+
+void HudwarpProcess::Finish()
+{
+	// Set the current blend state
+	ID3D11BlendState* pOriginalBlendState;
+	float oldBlendFactor[4];
+	unsigned int oldSampleMask;
+	m_pContext->OMGetBlendState(&pOriginalBlendState, oldBlendFactor, &oldSampleMask);
+
+	// Get current shader state
+	ID3D11VertexShader* pOriginalVertexShader;
+	ID3D11PixelShader* pOriginalPixelShader;
+	m_pContext->VSGetShader(&pOriginalVertexShader, 0, 0);
+	m_pContext->PSGetShader(&pOriginalPixelShader, 0, 0);
+
+	ID3D11Buffer* pOriginalVertexBuffer;
+	UINT originalVertexStride = 0;
+	UINT originalVertexOffset = 0;
+	ID3D11InputLayout* pOriginalVertexLayout;
+	ID3D11Buffer* pOriginalIndexBuffer;
+	DXGI_FORMAT originalIndexFormat;
+	UINT originalIndexOffset = 0;
+	D3D11_PRIMITIVE_TOPOLOGY originalPrimitiveTopology;
+	m_pContext->IAGetVertexBuffers(0, 1, &pOriginalVertexBuffer, &originalVertexStride, &originalVertexOffset);
+	m_pContext->IAGetInputLayout(&pOriginalVertexLayout);
+	m_pContext->IAGetIndexBuffer(&pOriginalIndexBuffer, &originalIndexFormat, &originalIndexOffset);
+	m_pContext->IAGetPrimitiveTopology(&originalPrimitiveTopology);
+
+	unsigned int originalNumViewports = D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
+	D3D11_VIEWPORT* pOriginalViewports = nullptr;
+	m_pContext->RSGetViewports(&originalNumViewports, pOriginalViewports);
+
+	// Set the blend state	
+	m_pContext->OMSetBlendState(m_pBlendState, NULL, 0xffffffff);
+
+	// Set the render target to swapchain buffer
+	m_pContext->OMSetRenderTargets(1, &m_pOriginalRenderTargetView, NULL);
+
+	// Set the shaders
+	m_pContext->VSSetShader(pVertexShader, 0, 0);
+	m_pContext->PSSetShader(pPixelShader, 0, 0);
+
+	// Setup vertices and indices
+	UINT stride = sizeof(Vertex);
+	UINT offset = 0;
+	m_pContext->IASetVertexBuffers(0, 1, &m_pVertexBuffer, &stride, &offset);
+	m_pContext->IASetInputLayout(m_pVertexLayout);
+	m_pContext->IASetIndexBuffer(m_pIndexBuffer, DXGI_FORMAT_R32_UINT, 0);
+	m_pContext->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+	// Update the constant buffer
+	ConstantBuffer cb;
+	cb.mProjection = mOrtho;
+	cb.aspectRatio = (float)m_width / (float)m_height;
+	cb.xWarp = m_hudwarpSettings.xWarp;
+	cb.xScale = m_hudwarpSettings.xScale;
+	cb.yWarp = m_hudwarpSettings.yWarp;
+	cb.yScale = m_hudwarpSettings.yScale;
+	cb.viewDist = m_hudwarpSettings.viewDist;
+
+	m_pContext->UpdateSubresource(m_pConstantBuffer, 0, 0, &cb, 0, 0);
+
+	// Set shader resources
+	m_pContext->VSSetConstantBuffers(0, 1, &m_pConstantBuffer);
+	m_pContext->PSSetShaderResources(0, 1, &m_pShaderResourceView);
+	m_pContext->PSSetSamplers(0, 1, &m_pSamplerState);
+	m_pContext->PSSetConstantBuffers(0, 1, &m_pConstantBuffer);
+
+	m_pContext->RSSetState(m_pCWcullMode);
+
+	// Draw the texture to the screen
+	m_pContext->DrawIndexed(6, 0, 0);
+
+	// **************************************************
+	// *** RESTORE STATE OTHERWISE WE GET VISUAL BUGS ***
+	// **************************************************
+	// Set the shaders
+	m_pContext->VSSetShader(pOriginalVertexShader, 0, 0);
+	m_pContext->PSSetShader(pOriginalPixelShader, 0, 0);
+	m_pContext->IASetVertexBuffers(0, 1, &pOriginalVertexBuffer, &originalVertexStride, &originalVertexOffset);
+	m_pContext->IASetInputLayout(pOriginalVertexLayout);
+	m_pContext->IASetIndexBuffer(pOriginalIndexBuffer, originalIndexFormat, originalIndexOffset);
+	m_pContext->IASetPrimitiveTopology(originalPrimitiveTopology);
+
+	// Set the render target back
+	m_pContext->OMSetRenderTargets(1, &m_pOriginalRenderTargetView, m_pOriginalDepthStencilView);
+
+	// Restore the blend state
+	m_pContext->OMSetBlendState(pOriginalBlendState, oldBlendFactor, oldSampleMask);
+}

--- a/bmedll/Hudwarp.h
+++ b/bmedll/Hudwarp.h
@@ -1,0 +1,186 @@
+#pragma once
+
+// Ported from TFORevive by Barnaby
+
+#include "pch.h"
+#include "TTFSDK.h"
+#include <d3d11.h>
+#include <DirectXMath.h>
+
+#pragma comment(lib, "d3d11.lib")
+
+using namespace DirectX;
+
+struct HudwarpSettings {
+	float xWarp;
+	float xScale;
+	float yWarp;
+	float yScale;
+	float viewDist;
+};
+
+class HudwarpProcess
+{
+public:
+	HudwarpProcess(ID3D11Device* pDevice, ID3D11DeviceContext** ppID3D11DeviceContext);
+	~HudwarpProcess();
+
+	void Begin();
+	void Finish();
+	void Resize(unsigned int w, unsigned int h);
+	void UpdateSettings(HudwarpSettings* hudwarpSettings);
+
+private:
+	ID3D11Device* m_pDevice;
+	ID3D11DeviceContext* m_pContext;
+	ID3D11Texture2D* m_pRenderTexture = NULL;
+	ID3D11RenderTargetView* m_pRenderTargetView = NULL;
+	ID3D11ShaderResourceView* m_pShaderResourceView = NULL;
+	ID3D11SamplerState* m_pSamplerState = NULL;
+	ID3D11BlendState* m_pBlendState = NULL;
+
+	ID3D11Buffer* m_pVertexBuffer = nullptr;
+	ID3D11InputLayout* m_pVertexLayout = nullptr;
+	ID3D11Buffer* m_pIndexBuffer = nullptr;
+	ID3D11Buffer* m_pConstantBuffer = nullptr;
+
+	ID3D11RasterizerState* m_pCWcullMode = NULL;
+
+	ID3D11RenderTargetView* m_pOriginalRenderTargetView = NULL;
+	ID3D11DepthStencilView* m_pOriginalDepthStencilView = NULL;
+
+	XMMATRIX mOrtho{};
+	HudwarpSettings m_hudwarpSettings{};
+
+	unsigned int m_width = 0;
+	unsigned int m_height = 0;
+};
+
+struct ConstantBuffer
+{
+	XMMATRIX mProjection;
+	float aspectRatio;
+	// Hudwarp settings
+	float xWarp;
+	float xScale;
+	float yWarp;
+	float yScale;
+	float viewDist;
+};
+
+struct Vertex
+{
+	XMFLOAT3 pos;
+	XMFLOAT2 texCoord;
+};
+
+// Must match hudScale in shader
+#define HUD_SAFE_AREA_SCALE 0.95f
+
+constexpr const char* hudwarpShader = R"(
+cbuffer ConstantBuffer : register(b0)
+{
+	matrix projection;
+	float aspectRatio;
+	// Hudwarp settings
+	float xWarp;
+	float xScale;
+	float yWarp;
+	float yScale;
+	float viewDist; 
+}
+// PSI (PixelShaderInput)
+struct PSI
+{
+	float4 pos : SV_POSITION;
+	float2 texCoord : TEXCOORD;
+};
+
+// VertexShader
+PSI VS( float4 pos : POSITION, float2 texCoord : TEXCOORD )
+{
+	PSI psi;
+	psi.texCoord = texCoord;
+	pos = mul( pos, projection );
+	psi.pos = pos;
+	return psi;
+}
+// PixelShader
+Texture2D<float4> Texture : register(t0);
+sampler Sampler : register(s0);
+
+// Scaling correction from sub_1800084F0_Hook
+float2 UndoHudScale(float2 texCoord)
+{
+	// IMPORTANT: must match value of HUD_SAFE_AREA_SCALE 
+	float hudScale = 0.95f;
+	float hudOffset = 0.5f - hudScale / 2.0f;
+
+	return texCoord * hudScale + hudOffset;
+}
+
+float2 NormalizeUV(float2 uv)
+{
+    if (aspectRatio > 1.0f)
+    {
+        uv.x *= aspectRatio;
+        uv.x /= 16.0f / 9.0f;
+    }
+	else if (aspectRatio < 1.0f)
+    {
+        uv.y /= aspectRatio;
+        uv.y *= 16.0f / 9.0f;
+    }
+    
+    return uv;
+}
+
+
+float2 Distort(float2 uv) 
+{
+	// skip this processing if warp is disabled
+	if (xWarp == 0.0f && yWarp == 0.0f)
+		return uv;
+
+	// i hate this, it's terrible
+	// BUT... it gets similar results to respawn's fucked algorithm so we stay winning
+	// :3
+
+	float2 uvNorm = NormalizeUV(uv);
+
+    float xWarpFactor = 0.159155f;
+    float newX = uv.x * (viewDist + (uvNorm.y * atan(xWarp * uvNorm.y) * xWarpFactor + xWarpFactor * xScale * 1.5f * sin(xWarp)));
+    
+    float yWarpFactor = 0.5f;
+    float newY = uv.y * (viewDist - (uvNorm.x * atan(yWarp * uvNorm.x) * yWarpFactor - yWarpFactor / 2.5f / yScale * sin(yWarp)));
+
+    return float2(newX, newY);
+}
+
+float4 PS(PSI psi) : SV_TARGET
+{
+	// Skip rendering if scale is 0 in either axis
+	if (xScale == 0.0f || yScale == 0.0f)
+	{
+		return float4(0.0f, 0.0f, 0.0f, 0.0f);
+	}
+
+	float2 uv = UndoHudScale(psi.texCoord);
+	uv -= 0.5f;
+	uv *= 2.0f;
+	uv /= float2(xScale, yScale);
+
+	uv = Distort(uv);
+
+	// Skip rendering if our calculate UVs are outside of the hud texture
+	if (uv.x < -1.0f || uv.x > 1.0f || uv.y < -1.0f || uv.y > 1.0f)
+	{
+		return float4(0.0f, 0.0f, 0.0f, 0.0f);
+	}
+
+	//return float4(uv, 0.0f, 1.0f);
+
+    float4 color = Texture.Sample(Sampler, uv / 2.0f + float2(0.5f, 0.5f));
+    return color;
+}
+)";

--- a/bmedll/MiscHooks.cpp
+++ b/bmedll/MiscHooks.cpp
@@ -1,0 +1,48 @@
+#include "pch.h"
+#include "Memory.h"
+#include "MiscHooks.h"
+
+void CreateMiscHook_Error(const std::string& err)
+{
+    std::cout << std::endl << "/////////// Error in CreateMiscHook:" << std::endl << err << std::endl << "///////////" << std::endl;
+    MessageBoxA(NULL, err.c_str(), "Error in CreateMiscHook", 0);
+}
+
+//MH_STATUS WINAPI CreateMiscHook(LPVOID pTarget, LPVOID pDetour, LPVOID* ppOriginal)
+MH_STATUS WINAPI CreateMiscHook(DWORD64 baseAddress, unsigned int offset, LPVOID pDetour, LPVOID* ppOriginal)
+{
+    static unsigned int counter = 0;
+    counter++;
+    LPVOID pTarget = (LPVOID)(baseAddress + offset);
+    auto ret = MH_CreateHook(pTarget, pDetour, ppOriginal);
+    if (ret != MH_OK)
+    {
+        CreateMiscHook_Error(fmt::sprintf("Error hooking function with index number %i at module's offset of 0x%X", counter, offset));
+    }
+    return ret;
+}
+
+MH_STATUS WINAPI CreateMiscHookNamed(const char* moduleName, const char* procName, LPVOID pDetour, LPVOID* ppOriginal)
+{
+    HMODULE hModule = GetModuleHandleA(moduleName);
+    if (!hModule)
+    {
+        CreateMiscHook_Error(fmt::sprintf("GetModuleHandle failed for %s (Error = 0x%X)", moduleName, GetLastError()));
+        return MH_ERROR_MODULE_NOT_FOUND;
+    }
+
+    void* exportPtr = GetProcAddress(hModule, procName);
+    if (!exportPtr)
+    {
+        CreateMiscHook_Error(fmt::sprintf("GetProcAddress failed for %s (ModuleName = %s, Error = 0x%X)", procName, moduleName, GetLastError()));
+        return MH_ERROR_FUNCTION_NOT_FOUND;
+    }
+
+    LPVOID pTarget = exportPtr;
+    auto ret = MH_CreateHook(pTarget, pDetour, ppOriginal);
+    if (ret != MH_OK)
+    {
+        CreateMiscHook_Error(fmt::sprintf("Error hooking function %s (0x%X) in %s", procName, exportPtr, moduleName));
+    }
+    return ret;
+}

--- a/bmedll/MiscHooks.h
+++ b/bmedll/MiscHooks.h
@@ -1,0 +1,4 @@
+#pragma once
+
+MH_STATUS WINAPI CreateMiscHook(DWORD64 baseAddress, unsigned int offset, LPVOID pDetour, LPVOID* ppOriginal);
+MH_STATUS WINAPI CreateMiscHookNamed(const char* moduleName, const char* procName, LPVOID pDetour, LPVOID* ppOriginal);

--- a/bmedll/MiscRenderHooks.cpp
+++ b/bmedll/MiscRenderHooks.cpp
@@ -2,44 +2,55 @@
 #include "tier0.h"
 #include "TTFSDK.h"
 #include "MiscHooks.h"
+#include "Hudwarp.h"
+
+#include <d3d11_1.h>
+
+bool shouldUseGPUHudwarp = false;
+bool isHudwarpDisabled = false;
+
+bool isRenderingHud = false;
+HudwarpProcess* hudwarpProcess = nullptr;
 
 typedef void(__fastcall* sub_18000BAC0_type)(float*, float*, float*);
 sub_18000BAC0_type sub_18000BAC0_org = nullptr;
 void __fastcall sub_18000BAC0(float* a1, float* a2, float* a3)
 {
-    static auto& hudwarp_disable = SDK().GetVstdlibCvar()->FindVar("hudwarp_disable")->GetIntRef();
-    if (hudwarp_disable) {
-        // Still perform scaling for HUD when warping is disabled
-        // Ported from TFORevive by Barnaby
-        float viewWidth = a1[2];
-        float viewHeight = a1[3];
+    // Ported from TFORevive by Barnaby
 
-        float xScale = a1[7];
-        float yScale = a1[9];
+    if (!shouldUseGPUHudwarp)
+    {
+        // If hudwarp is disabled and running on CPU do just the scaling
+        if (isHudwarpDisabled)
+        {
+            // Still perform scaling for HUD when warping is disabled
+            float viewWidth = a1[2];
+            float viewHeight = a1[3];
 
-        if (xScale < 1.0f)
+            float xScale = a1[7];
+            float yScale = a1[9];
+
             a3[0] = (a2[0] - 0.5f * viewWidth) * xScale + 0.5f * viewWidth;
-        else
-            a3[0] = a2[0];
-
-        if (yScale < 1.0f)
             a3[1] = (a2[1] - 0.5f * viewHeight) * yScale + 0.5f * viewHeight;
-        else
-            a3[1] = a2[1];
+            a3[2] = a2[2];
+            return;
+        }
 
-        a3[2] = a2[2];
-        return;
+        return sub_18000BAC0_org(a1, a2, a3);
     }
-    sub_18000BAC0_org(a1, a2, a3);
-}
 
-struct HudwarpSettings {
-    float xWarp;
-    float xScale;
-    float yWarp;
-    float yScale;
-    float viewDist;
-};
+    // Somewhat hacky but prevents hud from reaching bounds of render texture
+    // The value of hudScale MUST be the same as hudScale in the Hudwarp shader so it can undo this correctly
+    const float hudScale = HUD_SAFE_AREA_SCALE;
+    const float hudOffset = 0.5f - hudScale / 2.0f;
+
+    float viewWidth = a1[2];
+    float viewHeight = a1[3];
+
+    a3[0] = a2[0] * hudScale + hudOffset * viewWidth;
+    a3[1] = a2[1] * hudScale + hudOffset * viewHeight;
+    a3[2] = a2[2];
+}
 
 typedef void(__fastcall* CMatSystemSurface__ApplyHudwarpSettings_type)(void*, HudwarpSettings*, unsigned int, unsigned int);
 CMatSystemSurface__ApplyHudwarpSettings_type CMatSystemSurface__ApplyHudwarpSettings_org = nullptr;
@@ -64,9 +75,13 @@ void __fastcall CMatSystemSurface__ApplyHudwarpSettings(void* thisptr, HudwarpSe
         if (newSettings.yScale > 1.0f) newSettings.yScale = 1.0f;
     }
 
-    // If hudwarp is disabled do this
+    if (hudwarpProcess)
+        hudwarpProcess->UpdateSettings(&newSettings);
+
+    static ConVarRef hudwarp_use_gpu{ "hudwarp_use_gpu" };
+    // If using GPU hudwarp or hudwarp is disabled do this
     // Replace chopsize, it gets set from the cvar in CMatSystemSurface__ApplyHudwarpSettings
-    if (hudwarp_disable->GetInt())
+    if (hudwarp_use_gpu->GetInt() || hudwarp_disable->GetInt())
     {
         if (screenX > screenY) [[likely]]
             {
@@ -83,9 +98,157 @@ void __fastcall CMatSystemSurface__ApplyHudwarpSettings(void* thisptr, HudwarpSe
     hudwarp_chopsize->SetValueInt(originalChopsize);
 }
 
+ID3D11Device* pDevice;
+ID3D11DeviceContext** ppID3D11DeviceContext;
+ID3DUserDefinedAnnotation* pPerf;
+
+typedef __int64(*__fastcall SetPixMarker_type)(__int64 queuedRenderContext, unsigned long color, const char* pszName);
+FuncStaticWithType<SetPixMarker_type> SetPixMarker("materialsystem_dx11", 0x5D7E0);
+
+void QueueSetMarker(const char* markerName)
+{
+    static DWORD64 enginedllBaseAddress = Util::GetModuleBaseAddress("engine.dll");
+    static auto materials = *(__int64*)(enginedllBaseAddress + 0x318A688);
+    auto queuedRenderContext = (*(__int64(__fastcall**)(__int64))(*(_QWORD*)materials + 896i64))(materials);
+
+    SetPixMarker(queuedRenderContext, 0, markerName);
+}
+
+void QueueBeginEvent(const char* markerName)
+{
+    static DWORD64 enginedllBaseAddress = Util::GetModuleBaseAddress("engine.dll");
+    static auto materials = *(__int64*)(enginedllBaseAddress + 0x318A688);
+    auto queuedRenderContext = (*(__int64(__fastcall**)(__int64))(*(_QWORD*)materials + 896i64))(materials);
+
+    SetPixMarker(queuedRenderContext, 111111, markerName); // hijack color field for our purposes
+}
+
+void QueueEndEvent()
+{
+    static DWORD64 enginedllBaseAddress = Util::GetModuleBaseAddress("engine.dll");
+    static auto materials = *(__int64*)(enginedllBaseAddress + 0x318A688);
+    auto queuedRenderContext = (*(__int64(__fastcall**)(__int64))(*(_QWORD*)materials + 896i64))(materials);
+
+    SetPixMarker(queuedRenderContext, 222222, ""); // hijack color field for our purposes
+}
+
+void HudRenderStart()
+{
+    if (!shouldUseGPUHudwarp)
+        return;
+
+    if (hudwarpProcess)
+        hudwarpProcess->Begin();
+}
+
+void HudRenderFinish()
+{
+    if (!shouldUseGPUHudwarp)
+        return;
+
+    if (hudwarpProcess)
+        hudwarpProcess->Finish();
+}
+
+typedef void(__fastcall* OnWindowSizeChanged_type)(unsigned int, unsigned int, bool);
+OnWindowSizeChanged_type OnWindowSizeChanged_org = nullptr;
+void __fastcall OnWindowSizeChanged(unsigned int w, unsigned int h, bool isInGame)
+{
+    OnWindowSizeChanged_org(w, h, isInGame);
+
+    if (hudwarpProcess)
+        hudwarpProcess->Resize(w, h);
+}
+
+HookedFuncStaticWithType<SetPixMarker_type> sub_5ADC0("materialsystem_dx11.dll", 0x5ADC0);
+__int64 __fastcall sub_5ADC0_Hook(__int64 queuedRenderContext, unsigned long color, const char* pszName)
+{
+    static unsigned int hudEventDepth = 0;
+
+    switch (color)
+    {
+    case 111111:
+        pPerf->BeginEvent(Util::Widen(pszName).c_str());
+
+        if (!strcmp(pszName, "HUD")) {
+            isRenderingHud = true;
+            HudRenderStart();
+        }
+
+        if (isRenderingHud)
+            hudEventDepth++;
+        break;
+    case 222222:
+        if (isRenderingHud)
+        {
+            hudEventDepth--;
+            if (hudEventDepth == 0)
+            {
+                isRenderingHud = false;
+                HudRenderFinish();
+            }
+        }
+
+        pPerf->EndEvent();
+        break;
+    default:
+        pPerf->SetMarker(Util::Widen(pszName).c_str());
+    }
+
+    return sub_5ADC0(queuedRenderContext, color, pszName);
+}
+
+typedef void(*__fastcall RenderHud_type)(__int64 a1, __int64 a2, __int64 a3);
+HookedFuncStaticWithType<RenderHud_type> RenderHud("client.dll", 0x2AE630);
+void __fastcall RenderHud_Hook(__int64 a1, __int64 a2, __int64 a3)
+{
+    // Update state once per frame to prevent possible issues with one or neither applying
+    static ConVarRef hudwarp_use_gpu{ "hudwarp_use_gpu" };
+    shouldUseGPUHudwarp = hudwarp_use_gpu->GetInt();
+
+    static ConVarRef hudwarp_disable{ "hudwarp_disable" };
+    isHudwarpDisabled = hudwarp_disable->GetInt();
+
+    QueueBeginEvent("HUD");
+    RenderHud(a1, a2, a3);
+    QueueEndEvent();
+}
+
+void SetupHudwarp()
+{
+    pDevice = *(ID3D11Device**)(Util::GetModuleBaseAddress("materialsystem_dx11.dll") + 0x290D88);
+    ppID3D11DeviceContext = (ID3D11DeviceContext**)(Util::GetModuleBaseAddress("materialsystem_dx11.dll") + 0x290D90);
+
+    HRESULT hr = (*ppID3D11DeviceContext)->QueryInterface(__uuidof(pPerf), reinterpret_cast<void**>(&pPerf));
+    if (FAILED(hr))
+        pPerf = nullptr;
+
+    hudwarpProcess = new HudwarpProcess(pDevice, ppID3D11DeviceContext);
+}
+
+typedef bool(__fastcall* sub_63D0_type)(HWND, unsigned int, __int64);
+sub_63D0_type sub_63D0_org;
+char __fastcall sub_63D0(HWND a1, unsigned int a2, __int64 a3)
+{
+    // Initialization of DirectX swapchain and related device/context setup
+    auto ret = sub_63D0_org(a1, a2, a3);
+
+    // Init GPU Hudwarp
+    SetupHudwarp();
+
+    return ret;
+}
+
 void DoMiscRenderHooks()
 {
     DWORD64 vguimatsurfacedllBaseAddress = Util::GetModuleBaseAddress("vguimatsurface.dll");
+    DWORD64 materialsystem_dx11dllBaseAddress = Util::GetModuleBaseAddress("materialsystem_dx11.dll");
+
     CreateMiscHook(vguimatsurfacedllBaseAddress, 0xBAC0, &sub_18000BAC0, reinterpret_cast<LPVOID*>(&sub_18000BAC0_org));
     CreateMiscHook(vguimatsurfacedllBaseAddress, 0x15A30, &CMatSystemSurface__ApplyHudwarpSettings, reinterpret_cast<LPVOID*>(&CMatSystemSurface__ApplyHudwarpSettings_org));
+
+    RenderHud.Hook(RenderHud_Hook);
+
+    sub_5ADC0.Hook(sub_5ADC0_Hook);
+    CreateMiscHook(materialsystem_dx11dllBaseAddress, 0x63D0, &sub_63D0, reinterpret_cast<LPVOID*>(&sub_63D0_org));
 }

--- a/bmedll/MiscRenderHooks.cpp
+++ b/bmedll/MiscRenderHooks.cpp
@@ -84,9 +84,9 @@ void __fastcall CMatSystemSurface__ApplyHudwarpSettings(void* thisptr, HudwarpSe
     if (hudwarp_use_gpu->GetInt() || hudwarp_disable->GetInt())
     {
         if (screenX > screenY) [[likely]]
-            {
-                hudwarp_chopsize->SetValueInt(screenX);
-            }
+        {
+            hudwarp_chopsize->SetValueInt(screenX);
+        }
         else
         {
             hudwarp_chopsize->SetValueInt(screenY);
@@ -170,7 +170,8 @@ __int64 __fastcall sub_5ADC0_Hook(__int64 queuedRenderContext, unsigned long col
     case 111111:
         pPerf->BeginEvent(Util::Widen(pszName).c_str());
 
-        if (!strcmp(pszName, "HUD")) {
+        if (!strcmp(pszName, "HUD"))
+        {
             isRenderingHud = true;
             HudRenderStart();
         }

--- a/bmedll/MiscRenderHooks.cpp
+++ b/bmedll/MiscRenderHooks.cpp
@@ -33,8 +33,59 @@ void __fastcall sub_18000BAC0(float* a1, float* a2, float* a3)
     sub_18000BAC0_org(a1, a2, a3);
 }
 
+struct HudwarpSettings {
+    float xWarp;
+    float xScale;
+    float yWarp;
+    float yScale;
+    float viewDist;
+};
+
+typedef void(__fastcall* CMatSystemSurface__ApplyHudwarpSettings_type)(void*, HudwarpSettings*, unsigned int, unsigned int);
+CMatSystemSurface__ApplyHudwarpSettings_type CMatSystemSurface__ApplyHudwarpSettings_org = nullptr;
+void __fastcall CMatSystemSurface__ApplyHudwarpSettings(void* thisptr, HudwarpSettings* hudwarpSettings, unsigned int screenX, unsigned int screenY)
+{
+    // Ported from TFORevive by Barnaby
+
+    static ConVarRef hudwarp_chopsize{ "hudwarp_chopsize" };
+    unsigned int originalChopsize = hudwarp_chopsize->GetInt();
+
+    static ConVarRef hudwarp_disable{ "hudwarp_disable" };
+    HudwarpSettings newSettings = *hudwarpSettings;
+    if (hudwarp_disable->GetInt())
+    {
+        // Override hudwarp settings if hudwarp_disable is 1.
+        // NOTE: Comment below refers to original CPU version, we can set them to 0 when using our shader.
+        // Stuff breaks if you set the warp values to 0.
+        // Respawn set them to a min of 1deg in rads (0.017453292), we can do that too because it'll result in so little distortion you won't notice it :)
+        newSettings.xWarp = 0.0f;
+        if (newSettings.xScale > 1.0f) newSettings.xScale = 1.0f;
+        newSettings.yWarp = 0.0f;
+        if (newSettings.yScale > 1.0f) newSettings.yScale = 1.0f;
+    }
+
+    // If hudwarp is disabled do this
+    // Replace chopsize, it gets set from the cvar in CMatSystemSurface__ApplyHudwarpSettings
+    if (hudwarp_disable->GetInt())
+    {
+        if (screenX > screenY) [[likely]]
+            {
+                hudwarp_chopsize->SetValueInt(screenX);
+            }
+        else
+        {
+            hudwarp_chopsize->SetValueInt(screenY);
+        }
+    }
+
+    CMatSystemSurface__ApplyHudwarpSettings_org(thisptr, &newSettings, screenX, screenY);
+
+    hudwarp_chopsize->SetValueInt(originalChopsize);
+}
+
 void DoMiscRenderHooks()
 {
     DWORD64 vguimatsurfacedllBaseAddress = Util::GetModuleBaseAddress("vguimatsurface.dll");
     CreateMiscHook(vguimatsurfacedllBaseAddress, 0xBAC0, &sub_18000BAC0, reinterpret_cast<LPVOID*>(&sub_18000BAC0_org));
+    CreateMiscHook(vguimatsurfacedllBaseAddress, 0x15A30, &CMatSystemSurface__ApplyHudwarpSettings, reinterpret_cast<LPVOID*>(&CMatSystemSurface__ApplyHudwarpSettings_org));
 }

--- a/bmedll/MiscRenderHooks.cpp
+++ b/bmedll/MiscRenderHooks.cpp
@@ -1,0 +1,40 @@
+#include "pch.h"
+#include "tier0.h"
+#include "TTFSDK.h"
+#include "MiscHooks.h"
+
+typedef void(__fastcall* sub_18000BAC0_type)(float*, float*, float*);
+sub_18000BAC0_type sub_18000BAC0_org = nullptr;
+void __fastcall sub_18000BAC0(float* a1, float* a2, float* a3)
+{
+    static auto& hudwarp_disable = SDK().GetVstdlibCvar()->FindVar("hudwarp_disable")->GetIntRef();
+    if (hudwarp_disable) {
+        // Still perform scaling for HUD when warping is disabled
+        // Ported from TFORevive by Barnaby
+        float viewWidth = a1[2];
+        float viewHeight = a1[3];
+
+        float xScale = a1[7];
+        float yScale = a1[9];
+
+        if (xScale < 1.0f)
+            a3[0] = (a2[0] - 0.5f * viewWidth) * xScale + 0.5f * viewWidth;
+        else
+            a3[0] = a2[0];
+
+        if (yScale < 1.0f)
+            a3[1] = (a2[1] - 0.5f * viewHeight) * yScale + 0.5f * viewHeight;
+        else
+            a3[1] = a2[1];
+
+        a3[2] = a2[2];
+        return;
+    }
+    sub_18000BAC0_org(a1, a2, a3);
+}
+
+void DoMiscRenderHooks()
+{
+    DWORD64 vguimatsurfacedllBaseAddress = Util::GetModuleBaseAddress("vguimatsurface.dll");
+    CreateMiscHook(vguimatsurfacedllBaseAddress, 0xBAC0, &sub_18000BAC0, reinterpret_cast<LPVOID*>(&sub_18000BAC0_org));
+}

--- a/bmedll/TTFSDK.cpp
+++ b/bmedll/TTFSDK.cpp
@@ -305,7 +305,8 @@ void TTFSDK::Init()
     m_conCommandManager->RegisterCommand("set_cvar", SetCvarCC, "Set cvar to value", 0);
     m_conCommandManager->RegisterConVar("bme_version", BME_VERSION, FCVAR_UNLOGGED | FCVAR_DONTRECORD | FCVAR_SERVER_CANNOT_QUERY, "Current BME version");
     m_conCommandManager->RegisterConVar("cl_nocmdrate", "0", FCVAR_DONTRECORD, "Do not limit command packet rate by cl_cmdrate, instead allow dispatching one packet after every move command (so after every client frame)");
-    m_conCommandManager->RegisterConVar("hudwarp_disable", "0", FCVAR_DONTRECORD, "Disable HUD warping entirely for hugely improved performance. Affects how the HUD is displayed visually and breaks its \"warp-in\" effect at the beginning of the match in turn.");
+    m_conCommandManager->RegisterConVar("hudwarp_disable", "0", FCVAR_DONTRECORD, "Disable HUD warping entirely for hugely improved performance when not using GPU HUD warping. Affects how the HUD is displayed visually.");
+    m_conCommandManager->RegisterConVar("hudwarp_use_gpu", "0", FCVAR_DONTRECORD, "Run HUD warping on GPU for hugely improved performance. Slightly affects how the HUD is displayed visually.");
     m_conCommandManager->RegisterConVar("bme_skip_update", "0", FCVAR_DONTRECORD, "Set to 1 if you wish to skip auto-launching downloaded BME update");
 
 #if 0

--- a/bmedll/dllmain.cpp
+++ b/bmedll/dllmain.cpp
@@ -6,6 +6,7 @@
 #include "CrashReporting.h"
 #include "Updater.h"
 #include "Chat.h"
+#include "MiscHooks.h"
 
 HANDLE threadHandle;
 std::chrono::system_clock::time_point g_startTime;
@@ -39,53 +40,6 @@ DWORD WINAPI ConsoleInputThread(PVOID pThreadParameter)
         }
     }
     return 0;
-}
-
-/////////////////////
-
-void CreateMiscHook_Error(const std::string& err)
-{
-    std::cout << std::endl << "/////////// Error in CreateMiscHook:" << std::endl << err << std::endl << "///////////" << std::endl;
-    MessageBoxA(NULL, err.c_str(), "Error in CreateMiscHook", 0);
-}
-
-//MH_STATUS WINAPI CreateMiscHook(LPVOID pTarget, LPVOID pDetour, LPVOID* ppOriginal)
-MH_STATUS WINAPI CreateMiscHook(DWORD64 baseAddress, unsigned int offset, LPVOID pDetour, LPVOID* ppOriginal)
-{
-    static unsigned int counter = 0;
-    counter++;
-    LPVOID pTarget = (LPVOID)(baseAddress + offset);
-    auto ret = MH_CreateHook(pTarget, pDetour, ppOriginal);
-    if (ret != MH_OK)
-    {
-        CreateMiscHook_Error(fmt::sprintf("Error hooking function with index number %i at module's offset of 0x%X", counter, offset));
-    }
-    return ret;
-}
-
-MH_STATUS WINAPI CreateMiscHookNamed(const char* moduleName, const char* procName, LPVOID pDetour, LPVOID* ppOriginal)
-{
-    HMODULE hModule = GetModuleHandleA(moduleName);
-    if (!hModule)
-    {
-        CreateMiscHook_Error(fmt::sprintf("GetModuleHandle failed for %s (Error = 0x%X)", moduleName, GetLastError()));
-        return MH_ERROR_MODULE_NOT_FOUND;
-    }
-
-    void* exportPtr = GetProcAddress(hModule, procName);
-    if (!exportPtr)
-    {
-        CreateMiscHook_Error(fmt::sprintf("GetProcAddress failed for %s (ModuleName = %s, Error = 0x%X)", procName, moduleName, GetLastError()));
-        return MH_ERROR_FUNCTION_NOT_FOUND;
-    }
-
-    LPVOID pTarget = exportPtr;
-    auto ret = MH_CreateHook(pTarget, pDetour, ppOriginal);
-    if (ret != MH_OK)
-    {
-        CreateMiscHook_Error(fmt::sprintf("Error hooking function %s (0x%X) in %s", procName, exportPtr, moduleName));
-    }
-    return ret;
 }
 
 typedef char(__fastcall *CSourceAppSystemGroup_PreInit_type)(__int64 a1);

--- a/bmedll/dllmain.cpp
+++ b/bmedll/dllmain.cpp
@@ -266,16 +266,6 @@ void __fastcall Tier0_ThreadSetDebugName(HANDLE threadHandle, const char* name)
     _SetThreadDescription(threadHandle == 0 ? currentThread : threadHandle, Util::Widen(newName).c_str());
 }
 
-typedef void(__fastcall* sub_18000BAC0_type)(float*, __int64, __int64);
-sub_18000BAC0_type sub_18000BAC0_org = nullptr;
-void __fastcall sub_18000BAC0(float* a1, __int64 a2, __int64 a3)
-{
-    static auto& hudwarp_disable = SDK().GetVstdlibCvar()->FindVar("hudwarp_disable")->GetIntRef();
-    if (hudwarp_disable)
-        return;
-    sub_18000BAC0_org(a1, a2, a3);
-}
-
 typedef void(__fastcall* SQInstance_Finalize_type)(uintptr_t);
 SQInstance_Finalize_type SQInstance_Finalize_org = nullptr;
 void SQInstance_Finalize(uintptr_t thisptr)
@@ -394,7 +384,6 @@ void DoMiscHooks()
     if (!launcherdllBaseAddress) launcherdllBaseAddress = Util::GetModuleBaseAddress("launcher.dll");
     DWORD64 clientdllBaseAddress = Util::GetModuleBaseAddress("client.dll");
     DWORD64 enginedllBaseAddress = Util::GetModuleBaseAddress("engine.dll");
-    DWORD64 vguimatsurfacedllBaseAddress = Util::GetModuleBaseAddress("vguimatsurface.dll");
     DWORD64 vphysicsdllBaseAddress = Util::GetModuleBaseAddress("vphysics.dll");
     CreateMiscHook(launcherdllBaseAddress, 0x6B8E0, &CSourceAppSystemGroup_PreInit, reinterpret_cast<LPVOID*>(&CSourceAppSystemGroup_PreInit_org));
     CreateMiscHook(clientdllBaseAddress, 0x2C4220, &sub_1802C4220, reinterpret_cast<LPVOID*>(&sub_1802C4220_org));
@@ -412,7 +401,6 @@ void DoMiscHooks()
     CreateMiscHook(enginedllBaseAddress, 0x117240, &COM_ExplainDisconnection, reinterpret_cast<LPVOID*>(&COM_ExplainDisconnection_org));
     CreateMiscHook(enginedllBaseAddress, 0x137160, &Host_Disconnect, reinterpret_cast<LPVOID*>(&Host_Disconnect_org));
     CreateMiscHookNamed("tier0", "ThreadSetDebugName", &Tier0_ThreadSetDebugName, reinterpret_cast<LPVOID*>(&Tier0_ThreadSetDebugName_org));
-    CreateMiscHook(vguimatsurfacedllBaseAddress, 0xBAC0, &sub_18000BAC0, reinterpret_cast<LPVOID*>(&sub_18000BAC0_org));
     CreateMiscHook(launcherdllBaseAddress, 0x4D6D0, &SQInstance_Finalize, reinterpret_cast<LPVOID*>(&SQInstance_Finalize_org));
     CreateMiscHook(vphysicsdllBaseAddress, 0x100880, &sub_180100880, reinterpret_cast<LPVOID*>(&sub_180100880_org));
     CreateMiscHook(enginedllBaseAddress, 0x1A0F70, &CEngineAPI__Run, reinterpret_cast<LPVOID*>(&CEngineAPI__Run_org));
@@ -618,6 +606,10 @@ void main()
 
         SPDLOG_DEBUG("DoMiscHooks");
         DoMiscHooks();
+
+        SPDLOG_DEBUG("DoMiscRenderHooks");
+        extern void DoMiscRenderHooks();
+        DoMiscRenderHooks();
 
         extern void Setup_MMNotificationClient();
         Setup_MMNotificationClient();


### PR DESCRIPTION
Uses a shader to perform HUD warp.
Significant performance improvement when enabled.
Enable with: `hudwarp_use_gpu 1`

Additional changes:
- Change how `hudwarp_disable 1` works so that you get more FPS with it and it no longer breaks HUD scaling (warp-in effect)
- Moved common MiscHook code to `MiscHooks.cpp`